### PR TITLE
回答送信方法をCmd+Enter（Ctrl+Enter）に変更

### DIFF
--- a/frontend/src/composables/useKeyboard.ts
+++ b/frontend/src/composables/useKeyboard.ts
@@ -1,12 +1,32 @@
 import { onMounted, onUnmounted } from "vue";
 
-type KeyHandlerMap = Record<string, () => void>;
+/**
+ * キーボードイベントハンドラーの型
+ * KeyboardEventを受け取ることで、修飾キー（Cmd/Ctrl）などの情報にアクセスできる
+ */
+type KeyHandler = (event: KeyboardEvent) => void;
+type KeyHandlerMap = Record<string, KeyHandler>;
 
+/**
+ * キーボードショートカットを管理するcomposable
+ *
+ * @param handlers - キーとハンドラーのマップ
+ *
+ * @example
+ * useKeyboard({
+ *   Enter: (event) => {
+ *     // Cmd+Enter または Ctrl+Enter で送信
+ *     if (event.metaKey || event.ctrlKey) {
+ *       submit();
+ *     }
+ *   }
+ * });
+ */
 export function useKeyboard(handlers: KeyHandlerMap) {
   const onKeydown = (event: KeyboardEvent) => {
     const handler = handlers[event.key];
     if (!handler) return;
-    handler();
+    handler(event);
   };
 
   onMounted(() => {

--- a/frontend/src/pages/QuizPage.vue
+++ b/frontend/src/pages/QuizPage.vue
@@ -189,12 +189,16 @@ function shareToX() {
 }
 
 useKeyboard({
-  Enter: () => {
+  Enter: (event) => {
     if (state.value.phase === "question") {
-      onAnswer();
+      // Cmd+Enter (Mac) または Ctrl+Enter (Windows) で回答送信
+      if (event.metaKey || event.ctrlKey) {
+        onAnswer();
+      }
       return;
     }
     if (state.value.phase === "answered") {
+      // answered phase では通常の Enter で次へ進む
       onNext();
     }
   },
@@ -243,15 +247,20 @@ useKeyboard({
           <h2>{{ state.placeName }}</h2>
         </n-card>
 
-        <n-space justify="center">
-          <n-input
-            v-model:value="answerInput"
-            placeholder="ひらがなで入力"
-            style="width: 300px;"
-          />
-          <n-button type="primary" size="large" @click="onAnswer">
-            回答する
-          </n-button>
+        <n-space vertical align="center" :size="8">
+          <n-space justify="center">
+            <n-input
+              v-model:value="answerInput"
+              placeholder="ひらがなで入力"
+              style="width: 300px;"
+            />
+            <n-button type="primary" size="large" @click="onAnswer">
+              回答する
+            </n-button>
+          </n-space>
+          <p style="font-size: 12px; color: #999; margin: 0;">
+            Cmd/Ctrl+Enter で回答
+          </p>
         </n-space>
       </n-space>
     </div>


### PR DESCRIPTION
## 概要
IME入力中にEnterキーを押すと回答が誤送信される問題を解決するため、回答送信のショートカットをCmd+Enter（Mac）/ Ctrl+Enter（Windows）に変更

## 問題点
- 日本語入力（IME）で変換確定のためにEnterキーを押すと、回答が送信されてしまう
- 例: 「さっぽろし」→「札幌市」に変換する際、Enterで確定すると誤送信される

## 解決方法
- 回答送信を **Cmd+Enter（Mac）** または **Ctrl+Enter（Windows）** に変更
- 通常のEnterキーでは回答が送信されないため、IME変換が自由に行える
- answered phase（次の問題へ進む）では引き続き通常のEnterキーで進む

## 実装内容

### ✅ 変更したファイル
- **useKeyboard composable** (`src/composables/useKeyboard.ts`)
  - KeyboardEventをハンドラーに渡すように拡張
  - 修飾キー（metaKey, ctrlKey）の情報にアクセス可能に
- **QuizPage.vue** (`src/pages/QuizPage.vue`)
  - question phaseで Cmd+Enter / Ctrl+Enter で回答送信
  - answered phaseでは通常のEnterで次へ進む（変更なし）
  - UIに「Cmd/Ctrl+Enter で回答」を表示

## 関連Issue
Closes #33