### PR TITLE
Renderのcable DB設定を修正

### DIFF
--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -79,5 +79,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
+  primary: &primary_production
+    <<: *default
+    url: <%= ENV["DATABASE_URL"] %>
+  cache:
+    <<: *primary_production
+  queue:
+    <<: *primary_production
+  cable:
+    <<: *primary_production


### PR DESCRIPTION
概要

Render 本番環境において、solid_cable が cable 用のデータベース設定を要求し、
起動時にエラーが発生していたため、production の DB 設定を単一 DB に統一する。

⸻

対応内容
	•	production 環境において以下の DB 設定を 同一の DATABASE_URL に統一
	•	primary
	•	cable
	•	cache
	•	queue

