### PR TITLE
fix: Vercel SPAルーティングの404エラーを修正

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 問題

Vercel にデプロイした Vue.js SPA で、`/achievement` などのルートに直接アクセスすると 404 エラーが発生していました。

```
404: NOT_FOUND
Code: NOT_FOUND
```

## 原因

Vue Router を使用した SPA では、すべてのルーティングがクライアントサイドで処理されます。しかし、ブラウザで直接 `/achievement` にアクセスすると、Vercel はサーバー側で `/achievement/index.html` を探しますが、実際には `/index.html` しか存在しないため 404 エラーが返されます。

## 解決策

`vercel.json` を作成して、すべてのルートを `index.html` にリライトする設定を追加しました。

```json
{
  "rewrites": [
    {
      "source": "/(.*)",
      "destination": "/index.html"
    }
  ]
}
```

この設定により：
- すべてのパスへのアクセスが `index.html` にリダイレクトされる
- Vue Router がクライアントサイドで正しいコンポーネントをレンダリング
- `/achievement` などへの直接アクセスが正常に動作

## テスト

マージ後、以下を確認してください：
1. https://hokkaido-place-quiz.vercel.app/achievement に直接アクセス
2. 404 エラーが出ずに達成状況マップが表示される
3. リロードしても正常に表示される

Fixes #17 (部分的)
