### PR TITLE
OGP画像URLを絶対パスに変更

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="よめるべ？北海道" />
     <meta property="og:description" content="179市町村の地名を答えて、北海道の地図を完成させよう" />
-    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:image" content="https://hokkaido-place-quiz.vercel.app/og-image.png" />
     <meta property="og:url" content="https://hokkaido-place-quiz.vercel.app" />
     <meta property="og:site_name" content="よめるべ？北海道" />
 
@@ -21,7 +21,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="よめるべ？北海道" />
     <meta name="twitter:description" content="179市町村の地名を答えて、北海道の地図を完成させよう" />
-    <meta name="twitter:image" content="/og-image.png" />
+    <meta name="twitter:image" content="https://hokkaido-place-quiz.vercel.app/og-image.png" />
 
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />


### PR DESCRIPTION
## 概要
OGP画像がXで表示されないため、画像パスを絶対URLに変更する。

## 対応内容
- og:image / twitter:image を絶対URLに変更
