### PR TITLE
OGP画像メタ情報を追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,10 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="よめるべ？北海道" />
     <meta property="og:description" content="179市町村の地名を答えて、北海道の地図を完成させよう" />
-    <meta property="og:image" content="https://hokkaido-place-quiz.vercel.app/og-image.png" />
+    <meta property="og:image" content="https://hokkaido-place-quiz.vercel.app/og-image.png?v=2" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:url" content="https://hokkaido-place-quiz.vercel.app" />
     <meta property="og:site_name" content="よめるべ？北海道" />
 
@@ -21,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="よめるべ？北海道" />
     <meta name="twitter:description" content="179市町村の地名を答えて、北海道の地図を完成させよう" />
-    <meta name="twitter:image" content="https://hokkaido-place-quiz.vercel.app/og-image.png" />
+    <meta name="twitter:image" content="https://hokkaido-place-quiz.vercel.app/og-image.png?v=2" />
 
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />


### PR DESCRIPTION
## 概要
XでOGP画像が表示されないため、画像メタ情報を追加する。

## 対応内容
- og:image にバージョンクエリを付与
- og:image の width/height/type を追加
- twitter:image を更新
