### PR TITLE
行ってみたい機能の追加（お気に入り機能）

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -12,7 +12,7 @@
       <div class="header-actions">
         <router-link to="/favorites" custom v-slot="{ navigate }">
           <n-button @click="navigate" size="medium" square class="achievement-button">
-            ❤️ お気に入り
+            ❤️ 行ってみたい
           </n-button>
         </router-link>
 

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -9,18 +9,24 @@
         <img src="/header_title.png" alt="よめるべ？北海道" class="brand-title" />
       </router-link>
 
-      <router-link to="/achievement" custom v-slot="{ navigate }">
-        <n-button
-          @click="navigate"
-          
-          size="medium"
-          square
-          class="achievement-button"
-        >
-          <img src="/hokkaido.png" alt="" class="achievement-icon" />
-          市町村マップ
-        </n-button>
-      </router-link>
+      <div class="header-actions">
+        <router-link to="/favorites" custom v-slot="{ navigate }">
+          <n-button @click="navigate" size="medium" square class="achievement-button">
+            ❤️ お気に入り
+          </n-button>
+        </router-link>
+
+        <router-link to="/achievement" custom v-slot="{ navigate }">
+          <n-button
+            @click="navigate"
+            size="medium"
+            square class="achievement-button">
+            <img src="/hokkaido.png" alt="" class="achievement-icon" />
+            市町村マップ
+          </n-button>
+        </router-link>
+      </div>
+
     </div>
   </header>
 </template>
@@ -70,5 +76,11 @@
 .achievement-icon {
   width: 30px;
   height: 30px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 </style>

--- a/frontend/src/composables/useFavoriteMunicipalities.ts
+++ b/frontend/src/composables/useFavoriteMunicipalities.ts
@@ -1,0 +1,99 @@
+import { ref } from "vue";
+
+const STORAGE_KEY = "hokkaido-quiz-favorites";
+
+/**
+ * お気に入りの市町村の型定義
+ */
+interface FavoriteData {
+  municipalityName: string;
+  timestamp: number;
+}
+
+// モジュールスコープで定義
+const favorites = ref<Set<string>>(new Set());
+
+/**
+ * ローカルストレージからお気に入りデータを読み込む
+ */
+function loadFromLocalStorage(): Set<string> {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const data: FavoriteData[] = JSON.parse(stored);
+      return new Set(data.map(item => item.municipalityName));
+    }
+  } catch (error) {
+    console.error("Failed to load favorite municipalities from localStorage:", error);
+  }
+  return new Set();
+}
+
+/**
+ * ローカルストレージにお気に入りデータを保存する
+ */
+function saveToLocalStorage(favs: Set<string>) {
+  try {
+    const data: FavoriteData[] = Array.from(favs).map(name => ({
+      municipalityName: name,
+      timestamp: Date.now(),
+    }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error("Failed to save favorite municipalities to localStorage:", error);
+  }
+}
+
+// 初期化：モジュール読み込み時に実行
+favorites.value = loadFromLocalStorage();
+
+/**
+ * お気に入りの市町村の管理を行うcomposable
+ */
+export function useFavoriteMunicipalities() {
+  /**
+   * お気に入りを追加
+   */
+  function addFavorite(municipalityName: string): void {
+    favorites.value.add(municipalityName);
+    saveToLocalStorage(favorites.value);
+  }
+
+  /**
+   * お気に入りを削除
+   */
+  function removeFavorite(municipalityName: string): void {
+    favorites.value.delete(municipalityName);
+    saveToLocalStorage(favorites.value);
+  }
+
+  /**
+   * お気に入り状態をトグル
+   */
+  function toggleFavorite(municipalityName: string): boolean {
+    if (isFavorite(municipalityName)) {
+      removeFavorite(municipalityName);
+      return false;
+    } else {
+      addFavorite(municipalityName);
+      return true;
+    }
+  }
+
+  /**
+   * お気に入りかどうかをチェック
+   */
+  function isFavorite(municipalityName: string): boolean {
+    return favorites.value.has(municipalityName);
+  }
+
+  return {
+    favorites,
+    addFavorite,
+    removeFavorite,
+    toggleFavorite,
+    isFavorite,
+  };
+}
+
+    

--- a/frontend/src/pages/AnsweredPage.vue
+++ b/frontend/src/pages/AnsweredPage.vue
@@ -18,7 +18,7 @@ const { getTrivia } = useMunicipalityTrivia()
  * お気に入りボタンクリック時の処理
  */
 function onToggleFavorite() {
-  if(quizStore.state.placeName) {
+  if(quizStore.state.phase === 'answered') {
     quizStore.toggleFavorite(quizStore.state.placeName)
   }
 }

--- a/frontend/src/pages/AnsweredPage.vue
+++ b/frontend/src/pages/AnsweredPage.vue
@@ -15,6 +15,15 @@ const router = useRouter()
 const { getTrivia } = useMunicipalityTrivia()
 
 /**
+ * お気に入りボタンクリック時の処理
+ */
+function onToggleFavorite() {
+  if(quizStore.state.placeName) {
+    quizStore.toggleFavorite(quizStore.state.placeName)
+  }
+}
+
+/**
  * 次へボタンクリック時の処理
  * 1. quizStoreのnextQuestionを呼び出し
  * 2. 完了ならば/quiz/result、継続なら/quiz/questionへ遷移
@@ -55,6 +64,18 @@ useKeyboard({
             <span class="reading-label">よみ</span>
             <span class="reading-text">{{ quizStore.state.correctReading || '（正解入力）' }}</span>
           </div>
+          <!-- お気に入りボタン -->
+          <n-button
+            size="small"
+            class="favorite-button"
+            @click="onToggleFavorite">
+            <span class="favorite-icon">
+              {{ quizStore.isFavorite(quizStore.state.placeName) ? '❤️' : '🤍' }}
+            </span>
+            <span class="favorite-text">
+              行ってみたい
+            </span>
+          </n-button>
         </div>
       </n-card>
 
@@ -237,6 +258,34 @@ useKeyboard({
   font-size: 13px;
   line-height: 1.7;
   color: #3d3d3d;
+}
+
+/* お気に入りボタン */
+.favorite-button {
+  margin-top: 15px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 20px;
+  border-radius: 999px;
+  background-color: #f5f5f5;
+  transition: all 0.2s ease;
+}
+
+.favorite-button:hover {
+  background-color: #ffffff;
+  transform: scale(1.05);
+}
+
+.favorite-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.favorite-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
 }
 
 .answered-places {

--- a/frontend/src/pages/FavoritesPage.vue
+++ b/frontend/src/pages/FavoritesPage.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useFavoriteMunicipalities } from '../composables/useFavoriteMunicipalities'
+
+const { favorites, removeFavorite } = useFavoriteMunicipalities()
+
+// Setを配列に変換
+const favoriteList = computed(() => Array.from(favorites.value))
+</script>
+
+<template>
+  <div class="content-container">
+    <n-card class="favorites-card">
+      <!-- ヘッダー：件数表示 -->
+      <div class="favorites-header">
+        <h2 class="favorites-title">お気に入りの市町村</h2>
+        <span class="favorites-count">合計 {{ favoriteList.length }} 件</span>
+      </div>
+
+      <!-- 空状態 -->
+      <div v-if="favoriteList.length === 0" class="favorites-empty">
+        お気に入りに登録された市町村はありません。
+      </div>
+
+      <!-- お気に入りリスト -->
+      <div v-else class="favorites-list">
+        <div v-for="name in favoriteList" :key="name" class="favorite-item">
+          <span class="favorite-name">{{ name }}</span>
+          <n-button size="small" @click="removeFavorite(name)">
+            削除
+          </n-button>
+        </div>
+      </div>
+
+      <!-- クイズに戻るボタン -->
+      <n-space justify="center" class="action-area">
+        <router-link to="/">
+          <n-button type="primary" size="large" round class="return-button">
+            クイズに戻る
+          </n-button>
+        </router-link>
+      </n-space>
+    </n-card>
+  </div>
+</template>
+
+<style scoped>
+.content-container {
+  padding: 40px 20px;
+  background: transparent;
+}
+
+.favorites-card {
+  width: 100%;
+  max-width: 800px;
+  border-radius: 30px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.05);
+  padding: 20px;
+}
+
+.favorites-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.favorites-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0;
+}
+
+.favorites-count {
+  font-size: 14px;
+  color: #9aa4b2;
+}
+
+.favorites-empty {
+  text-align: center;
+  padding: 40px 0;
+  color: #9aa4b2;
+  font-size: 14px;
+}
+
+.favorites-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.favorite-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background-color: #f5f7f4;
+  border: 1px solid #e8ede6;
+}
+
+.favorite-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.action-area {
+  margin-top: 24px;
+}
+
+.return-button {
+  width: 100%;
+  max-width: 400px;
+  height: 40px;
+  border-radius: 32px;
+  font-size: 15px;
+  font-weight: 500;
+  background: linear-gradient(180deg, #67C23A 0%, #6db12a 100%);
+  transition: all 0.3s ease;
+}
+</style>

--- a/frontend/src/pages/FavoritesPage.vue
+++ b/frontend/src/pages/FavoritesPage.vue
@@ -13,16 +13,16 @@ const favoriteList = computed(() => Array.from(favorites.value))
     <n-card class="favorites-card">
       <!-- ヘッダー：件数表示 -->
       <div class="favorites-header">
-        <h2 class="favorites-title">お気に入りの市町村</h2>
+        <h2 class="favorites-title">行ってみたい市町村</h2>
         <span class="favorites-count">合計 {{ favoriteList.length }} 件</span>
       </div>
 
       <!-- 空状態 -->
       <div v-if="favoriteList.length === 0" class="favorites-empty">
-        お気に入りに登録された市町村はありません。
+        行ってみたい市町村はありません。
       </div>
 
-      <!-- お気に入りリスト -->
+      <!-- リスト -->
       <div v-else class="favorites-list">
         <div v-for="name in favoriteList" :key="name" class="favorite-item">
           <span class="favorite-name">{{ name }}</span>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,6 +4,7 @@ import QuestionPage from '../pages/QuestionPage.vue';
 import AnsweredPage from '../pages/AnsweredPage.vue';
 import ResultPage from '../pages/ResultPage.vue';
 import AchievementPage from '../pages/AchievementPage.vue';
+import FavoritesPage from '../pages/FavoritesPage.vue';
 import { useQuizStore } from '../stores/quizStore';
 
 const router = createRouter({
@@ -66,6 +67,11 @@ const router = createRouter({
       path: '/achievement',
       name: 'achievement',
       component: AchievementPage,
+    },
+    {
+      path: '/favorites',
+      name: 'favorites',
+      component: FavoritesPage,
     },
   ],
 });

--- a/frontend/src/stores/quizStore.ts
+++ b/frontend/src/stores/quizStore.ts
@@ -14,6 +14,7 @@ import {
 } from '../api/quizApi'
 import { useTimer } from '../composables/useTimer'
 import { useAchievedMunicipalities } from '../composables/useAchievedMunicipalities'
+import { useFavoriteMunicipalities } from '../composables/useFavoriteMunicipalities'
 
 /**
  * 出題した地名の情報
@@ -80,6 +81,9 @@ export const useQuizStore = defineStore('quiz', () => {
 
   // 正解済み市町村管理
   const achievements = useAchievedMunicipalities()
+
+  // お気に入り市町村管理
+  const favorites = useFavoriteMunicipalities()
 
   // ===================================
   // Getters (算出プロパティ)
@@ -335,5 +339,13 @@ ${url}
     markAsAchieved: achievements.markAsAchieved,
     isAchieved: achievements.isAchieved,
     achievedList: achievements.achievedList,
+
+    // Favorites (お気に入り市町村管理の公開)
+    // store が外部に公開する「名前（キー）」：実際に中身として使う「値（変数・関数）」
+    favorites: favorites.favorites,
+    addFavorite: favorites.addFavorite,
+    removeFavorite: favorites.removeFavorite,
+    toggleFavorite: favorites.toggleFavorite,
+    isFavorite: favorites.isFavorite,
   }
 })


### PR DESCRIPTION
## 概要

クイズの回答後に「行ってみたい」ボタンを押すと、一覧ページでチェックした市町村を確認できる機能を追加。

## 変更内容

- `useFavoriteMunicipalities` composable を追加（LocalStorage で永続化）
- `quizStore` にお気に入り機能を統合
- `AnsweredPage` に「行ってみたい」ボタンを追加
- `FavoritesPage` を新規作成（一覧表示・削除機能）
- `AppHeader` に「行ってみたい」ボタンを追加
- ルーティングに `/favorites` を追加