### PR TITLE
観光スポットの位置を地図上に表示する

### DIFF
--- a/frontend/src/components/PlacesList.vue
+++ b/frontend/src/components/PlacesList.vue
@@ -10,6 +10,9 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const emit = defineEmits<{
+  'places-loaded': [places: PlaceResult[]];
+}>();
 
 // Places API composable
 const { searchPlacesByMunicipality, getPhotoUrl } = usePlacesApi();
@@ -35,6 +38,7 @@ async function loadPlaces() {
   try {
     const results = await searchPlacesByMunicipality(props.placeName);
     places.value = results;
+    emit('places-loaded', results);
 
     if (results.length === 0) {
       hasError.value = true;

--- a/frontend/src/composables/usePlacesApi.ts
+++ b/frontend/src/composables/usePlacesApi.ts
@@ -24,6 +24,10 @@ export interface PlaceResult {
     widthPx?: number;
     heightPx?: number;
   }>;
+  location?: {
+    latitude: number;
+    longitude: number;
+  };
 }
 
 /**
@@ -138,7 +142,7 @@ async function fetchNearbyPlaces(
       headers: {
         'Content-Type': 'application/json',
         'X-Goog-Api-Key': apiKey,
-        'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.rating,places.userRatingCount,places.photos',
+        'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.rating,places.userRatingCount,places.photos,places.location',
       },
       body: JSON.stringify({
         locationRestriction: {

--- a/frontend/src/pages/AnsweredPage.vue
+++ b/frontend/src/pages/AnsweredPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useQuizStore } from '../stores/quizStore'
 import { useRouter } from 'vue-router'
 import { useKeyboard } from '../composables/useKeyboard'
@@ -6,11 +7,13 @@ import { useMunicipalityTrivia } from '../composables/useMunicipalityTrivia'
 import AnsweredMap from '../components/AnsweredMap.vue'
 import PlacesList from '../components/PlacesList.vue'
 import RouteInfo from '../components/RouteInfo.vue'
+import type { PlaceResult } from '../composables/usePlacesApi'
 
 /**
  * quizStoreとrouterを取得
  */
 const quizStore = useQuizStore()
+const touristSpots = ref<PlaceResult[]>([])
 const router = useRouter()
 const { getTrivia } = useMunicipalityTrivia()
 
@@ -81,7 +84,7 @@ useKeyboard({
 
       <div class="answered-main">
         <n-card class="answered-map">
-          <AnsweredMap :place-name="quizStore.state.placeName" />
+          <AnsweredMap :place-name="quizStore.state.placeName" :tourist-spots="touristSpots" />
         </n-card>
 
         <n-space vertical size="medium" class="answered-side">
@@ -111,7 +114,7 @@ useKeyboard({
           <div class="answered-card-icon" aria-hidden="true">🖼️</div>
           <div class="card-title">周辺の観光スポット</div>
         </div>
-        <PlacesList :place-name="quizStore.state.placeName" />
+        <PlacesList :place-name="quizStore.state.placeName" @places-loaded="spots => touristSpots = spots" />
       </n-card>
 
       <n-button type="primary" size="large" class="answer-button" @click="onNext">


### PR DESCRIPTION
## 概要

Close #41
観光スポットの位置を地図上にマーカー表示する機能を追加

## 変更内容

### `usePlacesApi.ts`
- `PlaceResult` 型に `location?: { latitude, longitude }` を追加
- `X-Goog-FieldMask` に `places.location` を追加

### `PlacesList.vue`
- 観光スポット取得完了後に `places-loaded` イベントを emit する

### `AnsweredPage.vue`
- `places-loaded` イベントで受け取った観光スポットデータを `touristSpots` に格納
- `AnsweredMap` に `tourist-spots` props として渡す

### `AnsweredMap.vue`
- `touristSpots` props を受け取り、各スポットの座標に `AdvancedMarkerElement` を配置
- マーカークリックで `InfoWindow` にスポット名を表示